### PR TITLE
NUCJODATIME-23: Fixed inconsistent value conversion when using differ…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 /bin
+/.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,12 @@
             <version>${jodatime.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>2.2.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!-- Build process -->

--- a/src/main/java/org/datanucleus/store/types/jodatime/converters/JodaLocalDateSqlDateConverter.java
+++ b/src/main/java/org/datanucleus/store/types/jodatime/converters/JodaLocalDateSqlDateConverter.java
@@ -20,6 +20,7 @@ package org.datanucleus.store.types.jodatime.converters;
 import java.sql.Date;
 
 import org.datanucleus.store.types.converters.TypeConverter;
+import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 
 /**
@@ -38,7 +39,7 @@ public class JodaLocalDateSqlDateConverter implements TypeConverter<LocalDate, D
         {
             return null;
         }
-        return new Date(ld.toDateTimeAtStartOfDay().getMillis());
+        return new Date(ld.toDateTimeAtStartOfDay(DateTimeZone.UTC).getMillis());
     }
 
     /* (non-Javadoc)
@@ -51,6 +52,6 @@ public class JodaLocalDateSqlDateConverter implements TypeConverter<LocalDate, D
             return null;
         }
 
-        return new LocalDate(date.getTime());
+        return new LocalDate(date.getTime(), DateTimeZone.UTC);
     }
 }

--- a/src/test/java/org/datanucleus/store/types/jodatime/test/LocalDateTimeTests.java
+++ b/src/test/java/org/datanucleus/store/types/jodatime/test/LocalDateTimeTests.java
@@ -1,0 +1,38 @@
+package org.datanucleus.store.types.jodatime.test;
+
+import org.datanucleus.store.types.converters.TypeConverter;
+import org.datanucleus.store.types.jodatime.converters.JodaLocalDateSqlDateConverter;
+import org.datanucleus.store.types.jodatime.converters.JodaLocalDateStringConverter;
+import org.joda.time.DateTimeZone;
+import org.joda.time.LocalDate;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Created by Rodrigo Quesada on 06/10/15.
+ */
+public class LocalDateTimeTests {
+
+    private static class TimeZones {
+        static final String JAPAN = "Asia/Tokyo";
+        static final String COSTA_RICA = "America/Costa_Rica";
+    }
+
+    private <T> void assert_localDateConversionIsUnaffectedByTimeZoneChanges(TypeConverter<LocalDate, T> converter) {
+        LocalDate expectedDate = new LocalDate(2015, 10, 5);
+
+        DateTimeZone.setDefault(DateTimeZone.forID(TimeZones.JAPAN));
+        T dataStoreType = converter.toDatastoreType(expectedDate);
+        DateTimeZone.setDefault(DateTimeZone.forID(TimeZones.COSTA_RICA));
+        LocalDate actualDate = converter.toMemberType(dataStoreType);
+
+        assertThat(actualDate).isEqualTo(expectedDate);
+    }
+
+    @Test
+    public void localDateConversionIsUnaffectedByTimeZoneChanges() {
+        assert_localDateConversionIsUnaffectedByTimeZoneChanges(new JodaLocalDateStringConverter());
+        assert_localDateConversionIsUnaffectedByTimeZoneChanges(new JodaLocalDateSqlDateConverter());
+    }
+}


### PR DESCRIPTION
…ent timezones for LocalDate fields persisted as SqlDate datastore type.
