### PR TITLE
Fixed OSGi issues which prevents bundle from starting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,8 @@
                         <Bundle-SymbolicName>org.datanucleus.store.types.jodatime;singleton:=true</Bundle-SymbolicName>
                         <Import-Package>
                             org.joda*;version="${jodatime.version}",
-                            org.datanucleus.store.rdbms*;version="${dn.rdbms.version}";resolution:=optional,,
+                            org.datanucleus.store.rdbms*;version="${dn.rdbms.version}";resolution:=optional,
+                            !org.datanucleus.store.types.jodatime*,
                             org.datanucleus*;version="${dn.core.version}",
                             *;resolution:=optional
                         </Import-Package>


### PR DESCRIPTION
This PR addresses multiple issues which contribute to the bundle not to starting in an OSGi environment. The problems mostly arise from OSGi considering a version with a qualifier to be higher then a version without one. So 6.0.0.m1 is higher then 6.0.0 according to OSGi.

By default the Maven bundle plugin will not add the Maven qualifier to the version of the packages. Meaning Maven version 6.0.0-release will become a package export version of 6.0.0. However the import statements generated will have a qualifier because the instructions in the current POM explicitly contain the version with qualifier.

The org.datanucleus*;version="${dn.core.version}" import intended to import the Core DataNucleus bundle also triggers adding imports for packages within this bundle (org.datanucleus.store.types.geospatial) but with the wrong version.

Combining these issues leads to the bundle not starting. This PR addresses that.

This PR is similar to https://github.com/datanucleus/datanucleus-geospatial/pull/17.